### PR TITLE
Dev/wilson

### DIFF
--- a/src/features/source/browser/components/ColumnHeaders/ColumnHeaders.tsx
+++ b/src/features/source/browser/components/ColumnHeaders/ColumnHeaders.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useRef } from 'react'
 import { ChevronUp, ChevronDown, GripVertical } from 'lucide-react'
 import type { ColumnConfig } from '../../types'
 
@@ -42,6 +42,25 @@ export const ColumnHeaders = memo(function ColumnHeaders({
 }: ColumnHeadersProps) {
   const visibleColumns = columns.filter((c) => c.visible)
 
+  // A resize drag ends with a mouseup that the browser turns into a click on the
+  // header. Without this guard that click would sort the column. We flag the
+  // resize interaction and skip the trailing sort click.
+  const suppressSortRef = useRef(false)
+
+  const handleResizeMouseDown = (e: React.MouseEvent, columnId: string) => {
+    suppressSortRef.current = true
+    onResize(e, columnId)
+
+    const clearOnMouseUp = () => {
+      // Defer past the click event that fires immediately after mouseup
+      window.setTimeout(() => {
+        suppressSortRef.current = false
+      }, 0)
+      document.removeEventListener('mouseup', clearOnMouseUp)
+    }
+    document.addEventListener('mouseup', clearOnMouseUp)
+  }
+
   return (
     <thead>
       <tr>
@@ -55,7 +74,10 @@ export const ColumnHeaders = memo(function ColumnHeaders({
               ${draggingColumn === column.id ? 'dragging opacity-50' : ''} 
               ${dragOverColumn === column.id ? 'drag-over bg-plm-accent/10' : ''}
             `}
-            onClick={() => column.sortable && onSort(column.id)}
+            onClick={() => {
+              if (suppressSortRef.current) return
+              if (column.sortable) onSort(column.id)
+            }}
             onContextMenu={onContextMenu}
             onDragOver={(e) => onDragOver(e, column.id)}
             onDragLeave={onDragLeave}
@@ -77,7 +99,7 @@ export const ColumnHeaders = memo(function ColumnHeaders({
             </div>
             <div
               className={`column-resize-handle ${resizingColumn === column.id ? 'resizing' : ''}`}
-              onMouseDown={(e) => onResize(e, column.id)}
+              onMouseDown={(e) => handleResizeMouseDown(e, column.id)}
             />
           </th>
         ))}

--- a/src/features/source/browser/components/FileList/cells/CopyHighlightInput.tsx
+++ b/src/features/source/browser/components/FileList/cells/CopyHighlightInput.tsx
@@ -1,0 +1,43 @@
+/**
+ * Read-only, auto-selected input used to "highlight" a cell's text for copying.
+ *
+ * Mirrors the Name column's highlight mode (see NameCell.tsx): shown when a value
+ * is not editable (file not checked out) so users can cleanly select + copy the
+ * text without being able to change it.
+ */
+import { useEffect, useRef } from 'react'
+
+interface CopyHighlightInputProps {
+  value: string
+  onExit: () => void
+}
+
+export function CopyHighlightInput({ value, onExit }: CopyHighlightInputProps): React.ReactNode {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      readOnly
+      value={value}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          onExit()
+        }
+        e.stopPropagation()
+      }}
+      onBlur={onExit}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onDragStart={(e) => e.preventDefault()}
+      draggable={false}
+      className="w-full bg-plm-bg border border-plm-border rounded px-1 py-0 text-sm text-plm-fg focus:outline-none focus:ring-1 focus:ring-plm-border select-text cursor-text"
+    />
+  )
+}

--- a/src/features/source/browser/components/FileList/cells/DescriptionCell.tsx
+++ b/src/features/source/browser/components/FileList/cells/DescriptionCell.tsx
@@ -8,9 +8,12 @@
  * NOTE: Drawing files can have their description locked via settings because
  * it typically comes from the referenced model, not from editable properties.
  */
+import { useState } from 'react'
 import { ArrowLeft, Box } from 'lucide-react'
 import { usePDMStore } from '@/stores/pdmStore'
 import { useFilePaneContext, useFilePaneHandlers } from '../../../context'
+import { useCellSlowHighlight } from '../../../hooks/useCellSlowHighlight'
+import { CopyHighlightInput } from './CopyHighlightInput'
 import type { CellRendererBaseProps } from './types'
 
 export function DescriptionCell({ file }: CellRendererBaseProps): React.ReactNode {
@@ -23,6 +26,10 @@ export function DescriptionCell({ file }: CellRendererBaseProps): React.ReactNod
 
   // Drawing lockout setting
   const lockDrawingDescription = usePDMStore((s) => s.lockDrawingDescription)
+
+  // Read-only "highlight for copying" mode (shown when the value can't be edited)
+  const [isHighlighting, setIsHighlighting] = useState(false)
+  const handleSlowHighlightClick = useCellSlowHighlight(() => setIsHighlighting(true))
 
   if (file.isDirectory) return ''
 
@@ -63,11 +70,16 @@ export function DescriptionCell({ file }: CellRendererBaseProps): React.ReactNod
       : file.pdmData?.description || '-'
   const hasValue = displayValue !== '-'
 
+  // Read-only highlight mode for copying (only for non-editable cells with a value)
+  if (isHighlighting && !canEditDescription && hasValue) {
+    return <CopyHighlightInput value={displayValue} onExit={() => setIsHighlighting(false)} />
+  }
+
   // Get appropriate tooltip
   const getTooltip = () => {
     if (isDrawingLocked) return 'Drawing description is inherited from the referenced model'
     if (canEditDescription) return displayValue !== '-' ? displayValue : 'Click to edit'
-    return 'Check out file to edit'
+    return hasValue ? `${displayValue} • Check out file to edit` : 'Check out file to edit'
   }
 
   return (
@@ -79,8 +91,11 @@ export function DescriptionCell({ file }: CellRendererBaseProps): React.ReactNod
           e.stopPropagation()
           e.preventDefault()
           handleStartCellEdit(file, 'description')
+        } else if (hasValue) {
+          // Non-editable values: slow double-click opens read-only copy box
+          // (fast double-click still bubbles to the row to open the file)
+          handleSlowHighlightClick(e)
         }
-        // Allow click through for text selection when not editable
       }}
       onMouseDown={(e) => {
         // Only stop propagation for editable cells to prevent row selection during edit

--- a/src/features/source/browser/components/FileList/cells/ItemNumberCell.tsx
+++ b/src/features/source/browser/components/FileList/cells/ItemNumberCell.tsx
@@ -14,6 +14,8 @@ import { Sparkles, Loader2, Check, ArrowLeft, Box } from 'lucide-react'
 import { useFilePaneContext, useFilePaneHandlers } from '../../../context'
 import { usePDMStore } from '@/stores/pdmStore'
 import { getNextSerialNumber, previewNextSerialNumber } from '@/lib/serialization'
+import { useCellSlowHighlight } from '../../../hooks/useCellSlowHighlight'
+import { CopyHighlightInput } from './CopyHighlightInput'
 import type { CellRendererBaseProps } from './types'
 
 export function ItemNumberCell({ file }: CellRendererBaseProps): React.ReactNode {
@@ -47,6 +49,10 @@ export function ItemNumberCell({ file }: CellRendererBaseProps): React.ReactNode
 
   // Local state for generation
   const [isGenerating, setIsGenerating] = useState(false)
+
+  // Read-only "highlight for copying" mode (shown when the value can't be edited)
+  const [isHighlighting, setIsHighlighting] = useState(false)
+  const handleSlowHighlightClick = useCellSlowHighlight(() => setIsHighlighting(true))
 
   // Confirmation state for inline BR number generation
   const [confirmingGenerate, setConfirmingGenerate] = useState(false)
@@ -293,11 +299,18 @@ export function ItemNumberCell({ file }: CellRendererBaseProps): React.ReactNode
     )
   }
 
+  // Read-only highlight mode for copying (only for non-editable cells with a value)
+  if (isHighlighting && !canEditItemNumber && hasValue) {
+    return <CopyHighlightInput value={displayValue} onExit={() => setIsHighlighting(false)} />
+  }
+
   // Get appropriate tooltip
   const getTooltip = () => {
     if (isDrawingLocked) return 'Drawing item number is inherited from the referenced model'
     if (canEditItemNumber) return 'Click to edit'
-    if (file.pdmData?.id) return 'Check out file to edit'
+    if (file.pdmData?.id) {
+      return hasValue ? `${displayValue} • Check out file to edit` : 'Check out file to edit'
+    }
     return 'Sign in to edit'
   }
 
@@ -305,6 +318,13 @@ export function ItemNumberCell({ file }: CellRendererBaseProps): React.ReactNode
     <div
       className="group/cell flex items-center h-full gap-1"
       data-no-drag
+      onClick={(e) => {
+        // Non-editable values: slow double-click opens read-only copy box
+        // (fast double-click still bubbles to the row to open the file)
+        if (!canEditItemNumber && hasValue) {
+          handleSlowHighlightClick(e)
+        }
+      }}
       onMouseDown={(e) => {
         // Only stop propagation for editable cells to prevent row selection during edit
         // For non-editable cells, allow native text selection

--- a/src/features/source/browser/hooks/useCellSlowHighlight.ts
+++ b/src/features/source/browser/hooks/useCellSlowHighlight.ts
@@ -1,0 +1,50 @@
+/**
+ * useCellSlowHighlight - slow double-click detection for a single table cell.
+ *
+ * Mirrors the Name column's slow double-click (see useSlowDoubleClick.ts): a fast
+ * double-click stays reserved for opening the file, while a slow "click, pause,
+ * click" opens the cell's read-only copy-highlight box.
+ *
+ * Fed from the cell's onClick. On the triggering (second) click it stops
+ * propagation so the row-level handler doesn't also highlight the file name.
+ */
+import { useCallback, useRef } from 'react'
+
+import { SLOW_DOUBLE_CLICK_MIN_MS, SLOW_DOUBLE_CLICK_MAX_MS } from '@/hooks/useSlowDoubleClick'
+
+export function useCellSlowHighlight(onSlowDoubleClick: () => void) {
+  const lastClickTimeRef = useRef(0)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  return useCallback(
+    (e: React.MouseEvent) => {
+      // Let modified clicks (range/multi-select) bubble untouched
+      if (e.shiftKey || e.ctrlKey || e.metaKey) return
+
+      const now = Date.now()
+      const timeDiff = now - lastClickTimeRef.current
+
+      if (timeDiff >= SLOW_DOUBLE_CLICK_MIN_MS && timeDiff <= SLOW_DOUBLE_CLICK_MAX_MS) {
+        // Slow double-click detected -> highlight this cell for copying.
+        // Stop propagation so the row doesn't also highlight the file name.
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+          timeoutRef.current = null
+        }
+        lastClickTimeRef.current = 0
+        e.stopPropagation()
+        onSlowDoubleClick()
+      } else {
+        // First click (or timing out of window) - record and let it bubble
+        // so normal row selection still happens.
+        lastClickTimeRef.current = now
+        if (timeoutRef.current) clearTimeout(timeoutRef.current)
+        timeoutRef.current = setTimeout(() => {
+          lastClickTimeRef.current = 0
+          timeoutRef.current = null
+        }, SLOW_DOUBLE_CLICK_MAX_MS + 100)
+      }
+    },
+    [onSlowDoubleClick],
+  )
+}

--- a/src/features/source/pending/PendingView.tsx
+++ b/src/features/source/pending/PendingView.tsx
@@ -666,6 +666,7 @@ export function PendingView({ onRefresh }: PendingViewProps) {
     expandedFolders,
     hideSolidworksTempFiles,
     setSelectedFiles: setStoreSelectedFiles,
+    setPendingScrollToFile,
     expandedPendingSections,
     togglePendingSection,
   } = usePDMStore()
@@ -969,13 +970,15 @@ export function PendingView({ onRefresh }: PendingViewProps) {
         setCurrentFolder(parentPath)
         // Highlight/select the file in the file browser
         setStoreSelectedFiles([localFile.path])
+        // Scroll the file list to bring the selected file into view
+        setPendingScrollToFile(localFile.path)
         return
       }
 
       // Fallback: show in system explorer
       window.electronAPI?.showInExplorer(filePath)
     },
-    [expandedFolders, toggleFolder, setCurrentFolder, setStoreSelectedFiles],
+    [expandedFolders, toggleFolder, setCurrentFolder, setStoreSelectedFiles, setPendingScrollToFile],
   )
 
   // Toggle expand/collapse for assembly groups with on-demand reference loading
@@ -1225,8 +1228,10 @@ export function PendingView({ onRefresh }: PendingViewProps) {
       setCurrentFolder(parentPath)
       // Highlight the file in the file browser
       setStoreSelectedFiles([file.path])
+      // Scroll the file list to bring the selected file into view
+      setPendingScrollToFile(file.path)
     },
-    [expandedFolders, toggleFolder, setCurrentFolder, setStoreSelectedFiles],
+    [expandedFolders, toggleFolder, setCurrentFolder, setStoreSelectedFiles, setPendingScrollToFile],
   )
 
   const selectAll = useCallback(() => {

--- a/src/stores/pdmStore.ts
+++ b/src/stores/pdmStore.ts
@@ -410,13 +410,27 @@ export const usePDMStore = create<PDMStoreState>()(
           // Ensure Christmas sleigh direction has default (new field for existing users)
           christmasSleighDirection:
             (persisted.christmasSleighDirection as 'push' | 'pull') || 'push',
-          // Ensure columns have all fields
-          columns: currentState.columns.map((defaultCol) => {
-            const persistedCol = ((persisted.columns as typeof currentState.columns) || []).find(
-              (c) => c.id === defaultCol.id,
-            )
-            return persistedCol ? { ...defaultCol, ...persistedCol } : defaultCol
-          }),
+          // Restore columns in the user's saved order (not the default order),
+          // merging in any fixed fields (label/sortable) from the current defaults.
+          // Widths/visibility come from the persisted config; new built-in columns
+          // added since the user last saved are appended at the end.
+          columns: (() => {
+            const persistedColumns =
+              (persisted.columns as typeof currentState.columns) || []
+            const persistedIds = new Set(persistedColumns.map((c) => c.id))
+            const ordered = persistedColumns
+              .map((persistedCol) => {
+                const defaultCol = currentState.columns.find((c) => c.id === persistedCol.id)
+                return defaultCol ? { ...defaultCol, ...persistedCol } : null
+              })
+              .filter((c): c is (typeof currentState.columns)[number] => c !== null)
+            for (const defaultCol of currentState.columns) {
+              if (!persistedIds.has(defaultCol.id)) {
+                ordered.push(defaultCol)
+              }
+            }
+            return ordered.length > 0 ? ordered : currentState.columns
+          })(),
           // Ensure cardViewFields have all fields (merge persisted with defaults for new fields)
           cardViewFields: defaultCardViewFields.map((defaultField) => {
             const persistedField = ((persisted.cardViewFields as CardViewFieldConfig[]) || []).find(


### PR DESCRIPTION
## Summary
- **fix: persist file explorer column order across restarts** — column widths and visibility already persisted, but the store's rehydrate merge rebuilt columns in the default order and dropped the user's saved ordering. Now the saved order is restored, with any new built-in columns appended.
- **feat: copy item number & description via highlight box** — a slow double-click on a non-editable Item Number/Description cell opens a read-only, auto-selected box (mirroring the Name column) so the value can be copied cleanly. Editing stays gated on checkout; a fast double-click still opens the file.
- **fix: prevent column resize from triggering a sort** — releasing the resize handle fired a click on the header that sorted the column. The resize interaction is now flagged so the trailing sort click is skipped.
- **feat: scroll file list to the file when navigating from Pending** — clicking a file in the Pending panel (Open Files, checked out, new files) selected it but didn't scroll it into view. Reuses the existing `pendingScrollToFile` mechanism.
## Test plan
- [x] `npm run typecheck` passes
- [x] Column order persists across a full app restart
- [x] Slow double-click copies Item Number/Description on checked-in files; fast double-click still opens the file; editing blocked unless checked out
- [x] Resizing a column no longer sorts it; header click still sorts; drag-to-reorder still works
- [x] Navigating from the Pending panel scrolls the file into view